### PR TITLE
[FEATURE][#2] Create GPIO Configuration

### DIFF
--- a/include/configuration.h
+++ b/include/configuration.h
@@ -1,3 +1,9 @@
+/**
+ * @file configuration.h
+ * @brief Configuration header file
+ * 
+ */
+
 #include <libopencm3/stm32/gpio.h> /**< Include the GPIO peripheral library */
 #include <libopencm3/stm32/rcc.h> /**< Include the RCC peripheral library */
 #include <libopencm3/stm32/exti.h> /**< Include the EXTI peripheral library */
@@ -15,12 +21,34 @@
 #define OVERRIDE_SWITCH_PORT GPIOA /**< Override switch port corresponds to port A */
 #define OVERRIDE_SWITCH_PIN GPIO8 /**< Define the override switch pin as PA8 */
 
+#define LED_PORT GPIOA /**< LED port corresponds to port A */
+#define LED_PIN GPIO10 /**< Define the LED pin as PA10 */
+
+#define FAN_PORT GPIOA /**< Fan port corresponds to port A */
+#define FAN_PIN GPIO9 /**< Define the fan pin as PA9 */
+
+#define TEMP_SENSOR_PORT GPIOA /**< Temperature sensor port corresponds to port A */
+#define TEMP_SENSOR_PIN GPIO0 /**< Define the temperature sensor pin as PA0 */
+
+#define BATTERY_LEVEL_PORT GPIOA /**< Battery level port corresponds to port A */
+#define BATTERY_LEVEL_PIN GPIO1 /**< Define the battery level pin as PA1 */
+
+#define MOTION_SENSOR_PORT GPIOA /**< Motion sensor port corresponds to port A */
+#define MOTION_SENSOR_PIN GPIO2 /**< Define the motion sensor pin as PA2 */
+
+#define INFRARED_SENSOR_PORT GPIOA /**< Infrared sensor port corresponds to port A */
+#define INFRARED_SENSOR_PIN GPIO3 /**< Define the infrared sensor pin as PA3 */
+
 /**
- * @brief Configures the GPIO pins for the alarm, motor, manual switch, and override switch
+ * @brief Configures the GPIO pins for the alarm, motor, manual switch, override switch, LED, fan, and sensors
  * 
  * The alarm pin is configured as an output, the motor pin is configured as an output in pin 6, port A,
- * the manual switch pin is configured as an input in pin 7 port A, and the override switch pin is configured
- * as an input in pin 8 port A.
+ * the manual switch pin is configured as an input in pin 7 port A, the override switch pin is configured
+ * as an input in pin 8 port A, the LED pin is configured as an output in pin 10 port A, the fan pin is configured
+ * as an output in pin 9 port A, the temperature sensor pin is configured as an input in pin 0 port A, the battery
+ * level pin is configured as an input in pin 1 port A, the motion sensor pin is configured as an input in pin 2 port A,
+ * and the infrared sensor pin is configured as an input in pin 3 port A.
+ * 
  */
 void configure_gpio(void);
 

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -61,3 +61,5 @@ void configure_gpio(void);
  * Note: The EXTI9_5 manages EXTI5 to EXTI9 interrupts.
  */
 void exti_setup(void);
+
+

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -1,0 +1,35 @@
+#include <libopencm3/stm32/gpio.h> /**< Include the GPIO peripheral library */
+#include <libopencm3/stm32/rcc.h> /**< Include the RCC peripheral library */
+#include <libopencm3/stm32/exti.h> /**< Include the EXTI peripheral library */
+#include <libopencm3/cm3/nvic.h> /**< Include the NVIC peripheral library */
+
+#define ALARM_PORT GPIOA /**< Alarm port corresponds to port A */
+#define ALARM_PIN GPIO5 /**< Define the alarm pin as PA5 */
+
+#define MOTOR_PORT GPIOA /**< Motor port corresponds to port A */
+#define MOTOR_PIN GPIO6 /**< Define the motor pin as PA6 */
+
+#define MANUAL_SWITCH_PORT GPIOA /**< Manual switch port corresponds to port A */
+#define MANUAL_SWITCH_PIN GPIO7 /**< Define the manual switch pin as PA7 */
+
+#define OVERRIDE_SWITCH_PORT GPIOA /**< Override switch port corresponds to port A */
+#define OVERRIDE_SWITCH_PIN GPIO8 /**< Define the override switch pin as PA8 */
+
+/**
+ * @brief Configures the GPIO pins for the alarm, motor, manual switch, and override switch
+ * 
+ * The alarm pin is configured as an output, the motor pin is configured as an output in pin 6, port A,
+ * the manual switch pin is configured as an input in pin 7 port A, and the override switch pin is configured
+ * as an input in pin 8 port A.
+ */
+void configure_gpio(void);
+
+/**
+ * @brief Configures the EXTI interrupt for the override switch
+ * 
+ * The AFIO clock is enabled, the EXTI9_5 interrupt is enabled in the NVIC, EXTI8 is configured as the source
+ * for the override switch pin, the interrupt is triggered on the falling edge, and the EXTI8 interrupt is enabled.
+ * 
+ * Note: The EXTI9_5 manages EXTI5 to EXTI9 interrupts.
+ */
+void exti_setup(void);

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -1,0 +1,36 @@
+#include "configuration.h" /**< Include the configuration header file */
+
+void configure_gpio(void) {
+    /* Configure the alarm pin as output */
+    gpio_set_mode(ALARM_PORT, GPIO_MODE_OUTPUT_2_MHZ,
+                  GPIO_CNF_OUTPUT_PUSHPULL, ALARM_PIN);
+    
+    /* Configure the motor pin as output */
+    gpio_set_mode(MOTOR_PORT, GPIO_MODE_OUTPUT_2_MHZ,
+                  GPIO_CNF_OUTPUT_PUSHPULL, MOTOR_PIN);
+
+    /* Configure the manual switch pin as input */
+    gpio_set_mode(MANUAL_SWITCH_PORT, GPIO_MODE_INPUT,
+                  GPIO_CNF_INPUT_PULL_UPDOWN, MANUAL_SWITCH_PIN);
+
+    /* Configure the override switch pin as input */
+    gpio_set_mode(OVERRIDE_SWITCH_PORT, GPIO_MODE_INPUT,
+                  GPIO_CNF_INPUT_PULL_UPDOWN, OVERRIDE_SWITCH_PIN);
+
+}
+
+void exti_setup(void)
+{
+    /* Enable AFIO clock */
+    rcc_periph_clock_enable(RCC_AFIO);
+
+    /* Enable EXT8 interrupt in the NVIC */
+    nvic_enable_irq(NVIC_EXTI9_5_IRQ);
+
+    /* Configure EXTI0 (PA8) for falling edge initially */
+    exti_select_source(EXTI8, OVERRIDE_SWITCH_PIN); /* Set PA8 as the EXTI8 source */
+    exti_set_trigger(EXTI8, EXTI_TRIGGER_FALLING);  /* Trigger interrupt on falling edge */
+    exti_enable_request(EXTI8);                     /* Enable EXTI8 interrupt */
+}
+
+

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -1,3 +1,8 @@
+/**
+ * @file configuration.c
+ * @brief Configuration source file
+ */
+
 #include "configuration.h" /**< Include the configuration header file */
 
 void configure_gpio(void) {
@@ -17,6 +22,30 @@ void configure_gpio(void) {
     gpio_set_mode(OVERRIDE_SWITCH_PORT, GPIO_MODE_INPUT,
                   GPIO_CNF_INPUT_PULL_UPDOWN, OVERRIDE_SWITCH_PIN);
 
+    /* Configure the LED pin as output */
+    gpio_set_mode(LED_PORT, GPIO_MODE_OUTPUT_2_MHZ,
+                  GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, LED_PIN);
+
+    /* Configure the fan pin as output */
+    gpio_set_mode(FAN_PORT, GPIO_MODE_OUTPUT_2_MHZ,
+                  GPIO_CNF_OUTPUT_PUSHPULL, FAN_PIN);
+
+    /* Configure the temperature sensor pin as input */
+    gpio_set_mode(TEMP_SENSOR_PORT, GPIO_MODE_INPUT,
+                  GPIO_CNF_INPUT_ANALOG, TEMP_SENSOR_PIN);
+
+    /* Configure the battery level pin as input */
+    gpio_set_mode(BATTERY_LEVEL_PORT, GPIO_MODE_INPUT,
+                  GPIO_CNF_INPUT_ANALOG, BATTERY_LEVEL_PIN);
+
+    /* Configure the motion sensor pin as input */
+    gpio_set_mode(MOTION_SENSOR_PORT, GPIO_MODE_INPUT,
+                  GPIO_CNF_INPUT_FLOAT, MOTION_SENSOR_PIN);
+
+    /* Configure the infrared sensor pin as input */
+    gpio_set_mode(INFRARED_SENSOR_PORT, GPIO_MODE_INPUT,
+                  GPIO_CNF_INPUT_FLOAT, INFRARED_SENSOR_PIN);
+
 }
 
 void exti_setup(void)
@@ -32,5 +61,4 @@ void exti_setup(void)
     exti_set_trigger(EXTI8, EXTI_TRIGGER_FALLING);  /* Trigger interrupt on falling edge */
     exti_enable_request(EXTI8);                     /* Enable EXTI8 interrupt */
 }
-
 


### PR DESCRIPTION
# **Dependencies**
This change depends on the **PlatformIO** environment configurations to ensure that hardware dependencies and platform-specific settings are available for the proper execution of GPIO and interrupt configurations.

# **What?**
GPIO configurations were added for the STM32F103 platform. Four GPIO ports were configured for input and output, and an external interrupt (EXTI) was configured on one of the pins.

# **Why?**
These configurations are necessary to interact with external devices, such as buttons or sensors, using the GPIO ports. Additionally, the interrupt was set up to allow for quick and efficient response to changes in pin state, improving the application’s ability to manage real-time events.

# **How?**
1. GPIO pins were configured for the appropriate modes (input/output).
2. The external interrupt (EXTI) was configured for one of the pins, specifically PA8, to detect state changes.
3. The NVIC was configured to enable the EXTI interrupt and adjust the priority.