### PR TITLE
[FEATURE][#3] Create PWM Configuration

### DIFF
--- a/include/configuration.h
+++ b/include/configuration.h
@@ -8,6 +8,7 @@
 #include <libopencm3/stm32/rcc.h> /**< Include the RCC peripheral library */
 #include <libopencm3/stm32/exti.h> /**< Include the EXTI peripheral library */
 #include <libopencm3/cm3/nvic.h> /**< Include the NVIC peripheral library */
+#include <libopencm3/stm32/timer.h> /**< Include the timer peripheral library */
 
 #define ALARM_PORT GPIOA /**< Alarm port corresponds to port A */
 #define ALARM_PIN GPIO5 /**< Define the alarm pin as PA5 */
@@ -39,6 +40,18 @@
 #define INFRARED_SENSOR_PORT GPIOA /**< Infrared sensor port corresponds to port A */
 #define INFRARED_SENSOR_PIN GPIO3 /**< Define the infrared sensor pin as PA3 */
 
+#define PRESCALER_VALUE 71999 /**< Define the prescaler value for the timer */
+/* Calculate it as follows: (timer_clock / desired_frequency) - 1
+ * 78MHz / (10000) - 1 */
+#define TIMER_PERIOD 0xFFFF /**< Full period of the timer */
+
+static uint32_t duty_cycle = 0; /**< Initialize the duty cycle to 0 */
+
+/**
+ * @brief Initializes the system clock to 72 MHz using an 8 MHz external crystal.
+ */
+void system_clock_setup(void);
+
 /**
  * @brief Configures the GPIO pins for the alarm, motor, manual switch, override switch, LED, fan, and sensors
  * 
@@ -61,5 +74,13 @@ void configure_gpio(void);
  * Note: The EXTI9_5 manages EXTI5 to EXTI9 interrupts.
  */
 void exti_setup(void);
+
+/**
+ * @brief Configures the timer to generate a PWM signal
+ * 
+ * The timer is configured to generate a PWM signal with a period of 10 ms and a duty cycle of 0%.
+ * 
+ */
+void config_pwm(void);
 
 

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -5,6 +5,12 @@
 
 #include "configuration.h" /**< Include the configuration header file */
 
+void system_clock_setup(void)
+{
+    /* Configure the system clock to 72 MHz using PLL and 8 MHz HSE */
+    rcc_clock_setup_pll(&rcc_hse_configs[RCC_CLOCK_HSE8_72MHZ]);
+}
+
 void configure_gpio(void) {
     /* Configure the alarm pin as output */
     gpio_set_mode(ALARM_PORT, GPIO_MODE_OUTPUT_2_MHZ,
@@ -61,4 +67,50 @@ void exti_setup(void)
     exti_set_trigger(EXTI8, EXTI_TRIGGER_FALLING);  /* Trigger interrupt on falling edge */
     exti_enable_request(EXTI8);                     /* Enable EXTI8 interrupt */
 }
+
+void config_pwm(void) 
+{
+    /* Enable the peripheral clock of GPIOA */
+    rcc_periph_clock_enable(RCC_TIM1);
+
+    /* Configure the reset and enable the timer peripheral */
+    rcc_periph_reset_pulse(RST_TIM1);
+
+    /* Configure the temporizer to obtain a frequency of 20 kHz */
+    timer_set_prescaler(TIM1, PRESCALER_VALUE); 
+
+    /* Configure the temporizer to count up to 999 */
+    timer_set_period(TIM1, TIMER_PERIOD);
+
+    /* Enable the output channel 2 as PWM */
+    timer_set_oc_mode(TIM1, TIM_OC2, TIM_OCM_PWM1);
+
+    /* Set the duty cicle at 0% */
+    timer_set_oc_value(TIM1, TIM_OC2, duty_cycle); 
+
+    /* Set the output polarity for OC2 as high */
+    timer_set_oc_polarity_high(TIM1, TIM_OC2);
+
+    /* Enable the output for OC2 */
+    timer_enable_oc_output(TIM1, TIM_OC2);
+
+    /* Enable the output channel 3 as PWM */
+    timer_set_oc_mode(TIM1, TIM_OC3, TIM_OCM_PWM1);
+
+    /* Set the duty cicle at 0% */
+    timer_set_oc_value(TIM1, TIM_OC3, duty_cycle); 
+
+    /* Set the output polarity for OC3 as high */
+    timer_set_oc_polarity_high(TIM1, TIM_OC3);
+
+    /* Enable the output for OC3 */
+    timer_enable_oc_output(TIM1, TIM_OC3);
+
+    /* Enable the break function */
+    timer_enable_break_main_output(TIM1);
+
+    /* Enable the temporizer */
+    timer_enable_counter(TIM1);
+}
+
 


### PR DESCRIPTION
# **Dependencies**
This change depends on the PlatformIO environment configuration to ensure that hardware dependencies and platform-specific settings are available for the proper execution of PWM configurations on Timer 1.

#  **What?**
The **Timer 1** channels 2 and 3 on the **STM32F103** platform were configured to generate **PWM** signals. The corresponding pins (PA9 and PA10) were configured in **alternate function (AF)** mode to allow PWM output on channels 2 and 3 of the timer. The **duty cycle** was initialized to **0%** (meaning the output signal is completely low initially), but it is a global variable that can be modified at runtime to adjust the PWM signal as needed.

# **Why?**
Using a global variable for the **duty cycle** allows flexibility in modifying the PWM signal during runtime. This is useful for applications where the **duty cycle** needs to change dynamically, such as controlling motor speed or LED brightness based on user input or other system conditions.

# **How?**
1. **Pin Configuration**:
   - The pins **PA9** (channel 2) and **PA10** (channel 3) are configured in **alternate function (AF)** mode to allow **Timer 1** to control the PWM output.

2. **Timer 1 Configuration**:
   - The **timer period** is set so that the timer runs every **10 ms** (giving a frequency of 100 Hz).
   
3. **PWM Channel Configuration**:
   - Both channels, **channel 2 (PA9)** and **channel 3 (PA10)**, are set to **PWM mode 1**.
   - A global variable called **`duty_cycle`** is used to control the duty cycle of the PWM signal. The value of this variable is used to adjust the **compare register** value for the timer channels.
