### PR TITLE
configuration of the adc 

### DIFF
--- a/include/configuration.h
+++ b/include/configuration.h
@@ -69,6 +69,9 @@
  */
 #define I2C_CR2_FREQ_36MHZ  36
 
+
+#define ADC_CHANNEL_TEMP_SENSOR 0 /**< Timer uses ADC chanell 0 */
+
 /**
  * @brief Configures the GPIO pins for the alarm, motor, manual switch, override switch, LED, fan, and sensors
  * 

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -118,3 +118,4 @@ void config_i2c(void);
  * indicating battery levels.
  */
 void adc_setup(void);
+

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -107,3 +107,14 @@ void exti_setup(void);
  * Before enabling the I2C peripheral, it is disabled to ensure a clean configuration.
  */
 void config_i2c(void);
+
+/**
+ * @brief Set up the ADC with the required configuration./**
+ *
+ * The ADC is used to convert analog signals from various sensors (temperature, 
+ * battery level, motion, and infrared sensor) into digital values that can be 
+ * processed by the microcontroller. This allows the system to monitor sensor 
+ * readings and make decisions such as closing the door, activating alarms, or 
+ * indicating battery levels.
+ */
+void adc_setup(void);

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -100,5 +100,3 @@ void adc_setup(void) {
     adc_calibrate(ADC1);
     
 }
-
-

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -90,7 +90,15 @@ void adc_setup(void) {
       /* Configure ADC */
     adc_power_off(ADC1);                     // Power off the ADC for configuration
     adc_disable_scan_mode(ADC1);             // Single conversion mode (one channel at a time)
+    adc_disable_external_trigger_regular(ADC1);
     adc_set_single_conversion_mode(ADC1);    // Single conversion per channel
-    adc_set_sample_time_on_all_channels(ADC1, ADC_SMPR_SMP_55DOT5CYC); // Sampling time
+    adc_set_sample_time(ADC1, ADC_CHANNEL_TEMP_SENSOR, ADC_SMPR_SMP_55DOT5CYC); /*  // Sampling time
+
+    /* Calibrate ADC */
     adc_power_on(ADC1);                      // Power on the ADC
+    adc_reset_calibration(ADC1);
+    adc_calibrate(ADC1);
+    
 }
+
+

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -85,3 +85,12 @@ void config_i2c(void)
     // Enable I2C to start communication
     i2c_peripheral_enable(I2C1);
 }
+
+void adc_setup(void) {
+      /* Configure ADC */
+    adc_power_off(ADC1);                     // Power off the ADC for configuration
+    adc_disable_scan_mode(ADC1);             // Single conversion mode (one channel at a time)
+    adc_set_single_conversion_mode(ADC1);    // Single conversion per channel
+    adc_set_sample_time_on_all_channels(ADC1, ADC_SMPR_SMP_55DOT5CYC); // Sampling time
+    adc_power_on(ADC1);                      // Power on the ADC
+}


### PR DESCRIPTION
### **Dependencies**

This change depends on the PlatformIO environment configuration to ensure the proper setup of ADC channels and platform-specific settings for reading analog sensor inputs.

### **What?**

The ADC of the STM32 microcontroller was configured to read analog signals from four specific sensors: temperature, battery level, motion, and infrared detection. The sensors are connected to analog pins (PA0, PA1, PA2, PA3), each corresponding to a specific ADC channel. The ADC is configured for 12-bit resolution and operates in continuous conversion mode, providing digital values for processing by the system.

### **Why?**

Configuring the ADC to read sensor inputs is crucial for monitoring the environment and taking appropriate actions based on the sensor data. For instance, the temperature sensor provides information about the room temperature, which can trigger actions such as closing the door if the temperature drops too low. The battery level sensor helps monitor the system’s power, and motion and infrared sensors allow the detection of threats. Having continuous ADC conversions ensures real-time data processing without manual intervention.

### **How?**

_Pin Configuration:_

The pins PA0, PA1, PA2, and PA3 are configured as analog inputs to read the analog signals from the temperature, battery level, motion, and infrared sensors, respectively.

_ADC Configuration:_

The ADC is configured for 12-bit resolution, providing a digital range of 0-4095 for each sensor reading.
The ADC is set to continuous conversion mode, ensuring that the ADC continuously converts the analog signals to digital values without manual triggering.

_ADC Channels:_

Channel 0 (PA0) is assigned to the temperature sensor.
Channel 1 (PA1) is assigned to the battery level sensor.
Channel 2 (PA2) is assigned to the motion sensor.
Channel 3 (PA3) is assigned to the infrared sensor.