### PR TITLE
Added system response functionality for temperature and PWM control

### DIFF
--- a/include/configuration.h
+++ b/include/configuration.h
@@ -11,6 +11,7 @@
 #include <libopencm3/cm3/nvic.h> /**< Include the NVIC peripheral library */
 #include <libopencm3/stm32/timer.h> /**< Include the timer peripheral library */
 #include <libopencm3/stm32/i2c.h> /**< Include the I2C library */
+#include <libopencm3/stm32/adc.h> /**< Include the adc peripheral library */
 
 #define ALARM_PORT GPIOA /**< Alarm port corresponds to port A */
 #define ALARM_PIN GPIO5 /**< Define the alarm pin as PA5 */
@@ -81,7 +82,6 @@ static uint32_t duty_cycle = 0; /**< Initialize the duty cycle to 0 */
  * @brief Initializes the system clock to 72 MHz using an 8 MHz external crystal.
  */
 void system_clock_setup(void);
-=======
 
 #define ADC_CHANNEL_TEMP_SENSOR 0 /**< Timer uses ADC chanell 0 */
   

--- a/include/system_response.h
+++ b/include/system_response.h
@@ -1,1 +1,63 @@
+#pragma once
 
+#include <libopencm3/stm32/adc.h>
+#include "configuration.h"
+
+#define ADC_RESOLUTION      4095 /**< 12-bit ADC max value */
+#define TEMP_SCALE_FACTOR   5    /**< Scale factor to convert voltage difference to temperature */
+#define PERCENTAGE_MAX      100  /**< Define the maximum percentage value (100%) */
+#define PWM_CHANNEL_2       2    /**< PWM channel 2 */
+
+/**
+ * @brief Processes the raw ADC value to calculate temperature.
+ *
+ * This function converts a raw ADC value from a temperature sensor into a 
+ * temperature in degrees Celsius. It assumes a 12-bit ADC with a reference 
+ * voltage of 3.3V, where the sensor output scales accordingly. 
+ * A typical temperature sensor such as the LM35 is assumed, which outputs 
+ * a linear voltage proportional to temperature.
+ *
+ * @param value The raw ADC value, ranging from 0 to 4095 (for a 12-bit ADC).
+ * @return uint16_t The calculated temperature in degrees Celsius.
+ *
+ * @note The calculation assumes:
+ *       - The ADC resolution is 12 bits (0-4095).
+ *       - The reference voltage is 3.3V.
+ *       - An offset and scaling factor as per the sensor characteristics.
+ */
+uint16_t process_temperature(uint16_t value);
+
+/**
+ * @brief Reads the temperature sensor value from the ADC.
+ * 
+ * This function configures the ADC to read from the temperature sensor channel,
+ * starts the conversion, waits for it to finish, and then returns the conversion result.
+ *
+ * @return uint16_t The ADC conversion result for the temperature sensor.
+ * 
+ * @note This function assumes that the ADC is properly initialized and configured
+ *       to read the temperature sensor channel. The result returned is the raw
+ *       ADC value, which needs further conversion to obtain the actual temperature.
+ */
+uint16_t read_temperature(void);
+
+/**
+ * @brief Set the PWM duty cycle for a specified output channel.
+ *
+ * This function calculates the PWM compare value based on the given duty cycle 
+ * percentage (0-100%) and sets the duty cycle for the specified output channel 
+ * of the timer (TIM1). It supports output channels 2 and 3 (OC2 and OC3) only. 
+ * If the channel number is not 2 or 3, the function will default to channel 3.
+ *
+ * @param duty_cycle The duty cycle percentage for the PWM signal. It should be
+ *                   a value between 0 and 100, where 0% is off and 100% is full speed.
+ * @param output_channel The PWM output channel to set the duty cycle for. 
+ *                       It should be either 2 or 3 (OC2 or OC3).
+ *                       - If `output_channel == 2`, the duty cycle is set for OC2.
+ *                       - If `output_channel == 3`, the duty cycle is set for OC3.
+ *                       If any other value is provided, the duty cycle will be set for OC3 by default.
+ *
+ * @note The output_channel must be either 2 or 3. If an invalid channel is passed,
+ *       the function will set the duty cycle for channel 3 (OC3).
+ */
+void set_pwm_duty_cycle(uint8_t duty_cycle, uint8_t output_channel);

--- a/src/system_response.c
+++ b/src/system_response.c
@@ -1,1 +1,38 @@
+#include "system_response.h"
 
+uint16_t process_temperature(uint16_t value) 
+{
+    uint16_t temperature = (value / ADC_RESOLUTION) * TEMP_SCALE_FACTOR;
+
+    return temperature;
+}
+
+uint16_t read_temperature(void) {
+    // Configurar el canal especificado
+    adc_set_regular_sequence(ADC1, 1, ADC_CHANNEL_TEMP_SENSOR); // Secuencia con un solo canal
+
+    // Iniciar la conversión
+    adc_start_conversion_regular(ADC1);
+
+    // Esperar a que la conversión termine
+    while (!(ADC1_SR & ADC_SR_EOC));
+
+    // Leer y devolver el resultado de la conversión
+    return adc_read_regular(ADC1);
+}
+
+void set_pwm_duty_cycle(uint8_t duty_cycle, uint8_t output_channel) {
+    // Calculate the PWM compare value based on the duty cycle
+    uint32_t pwm_value = (TIMER_PERIOD * duty_cycle) / PERCENTAGE_MAX;
+
+    if(output_channel == PWM_CHANNEL_2)
+    {
+        // Set the duty cycle value for the output channel 2 (OC2) of TIM1
+        timer_set_oc_value(TIM1, TIM_OC2, pwm_value);
+    }
+    else
+    {
+        // Set the duty cycle value for the output channel 3 (OC3) of TIM1
+        timer_set_oc_value(TIM1, TIM_OC3, pwm_value);
+    }
+}

--- a/src/system_response.c
+++ b/src/system_response.c
@@ -8,16 +8,16 @@ uint16_t process_temperature(uint16_t value)
 }
 
 uint16_t read_temperature(void) {
-    // Configurar el canal especificado
-    adc_set_regular_sequence(ADC1, 1, ADC_CHANNEL_TEMP_SENSOR); // Secuencia con un solo canal
+    // Configure temperature channel
+    adc_set_regular_sequence(ADC1, 1, ADC_CHANNEL_TEMP_SENSOR); // Sequence with one channel
 
-    // Iniciar la conversión
+    // Start the conversion
     adc_start_conversion_regular(ADC1);
 
-    // Esperar a que la conversión termine
+    // Wait for the conversion to finish
     while (!(ADC1_SR & ADC_SR_EOC));
 
-    // Leer y devolver el resultado de la conversión
+    // Read and return the result of the conversion
     return adc_read_regular(ADC1);
 }
 


### PR DESCRIPTION
This pull request introduces two files, `system_response.c` and `system_response.h`, to handle key system response features such as temperature sensor reading and PWM control.

**Files Added:**

1. **`system_response.c`**  
   - **`process_temperature`**: Converts raw ADC values from the temperature sensor into a temperature reading in degrees Celsius, using a predefined scale factor and ADC resolution.  
   - **`read_temperature`**: Configures the ADC to read the temperature sensor channel, starts the conversion, waits for completion, and returns the raw ADC result.  
   - **`set_pwm_duty_cycle`**: Sets the duty cycle of PWM channels (OC2 and OC3) by calculating the corresponding PWM compare value based on the desired duty cycle percentage.

2. **`system_response.h`**  
   - Contains function prototypes for the above functions, along with necessary macros for ADC resolution, temperature scaling factor, and PWM configuration.  
   - Detailed documentation for each function is provided, explaining how they interact with the ADC and PWM subsystems of the STM32 platform.

These changes ensure the system can handle temperature readings and adjust PWM duty cycles dynamically, making the system more responsive to environmental conditions.