### PR TITLE
[FEATURE][#2] Read battery ADC value

### DIFF
--- a/include/alarm.h
+++ b/include/alarm.h
@@ -10,4 +10,9 @@
 
 #define CONVERT_VALUE (100/4095) /**< The maximum value of the ADC */
 
+/**
+ * @brief Get the battery value and convert it to a percentage
+ * 
+ * @return uint16_t 
+ */
 uint16_t get_battery_value(void);

--- a/include/alarm.h
+++ b/include/alarm.h
@@ -10,4 +10,4 @@
 
 #define CONVERT_VALUE (100/4095) /**< The maximum value of the ADC */
 
-uint16_t get_channel_value(uint8_t channel);
+uint16_t get_battery_value(void);

--- a/include/alarm.h
+++ b/include/alarm.h
@@ -1,0 +1,13 @@
+/**
+ * @file alarm.h
+ * @brief alarm header file
+ * 
+ */
+#pragma once
+
+#include <libopencm3/stm32/adc.h> /**< Include the ADC library */
+#include "system_response.h" /**< Include the system response header file */
+
+#define CONVERT_VALUE (100/4095) /**< The maximum value of the ADC */
+
+uint16_t get_channel_value(uint8_t channel);

--- a/include/configuration.h
+++ b/include/configuration.h
@@ -42,6 +42,9 @@
 
 #define INFRARED_SENSOR_PORT GPIOA /**< Infrared sensor port corresponds to port A */
 #define INFRARED_SENSOR_PIN GPIO3 /**< Define the infrared sensor pin as PA3 */
+
+#define ADC_CHANNEL_TEMP_SENSOR 0 /**< Timer uses ADC channel 0 */
+#define ADC_CHANNEL_BATTERY_LEVEL 1 /**< Timer uses ADC channel 1 */
   
 /**
  * @brief I2C1 rise time in standard mode (100 kHz).
@@ -77,14 +80,12 @@
 #define TIMER_PERIOD 0xFFFF /**< Full period of the timer */
 
 static uint32_t duty_cycle = 0; /**< Initialize the duty cycle to 0 */
-
+  
 /**
  * @brief Initializes the system clock to 72 MHz using an 8 MHz external crystal.
  */
 void system_clock_setup(void);
 
-#define ADC_CHANNEL_TEMP_SENSOR 0 /**< Timer uses ADC chanell 0 */
-  
   
 /**
  * @brief Configures the GPIO pins for the alarm, motor, manual switch, override switch, LED, fan, and sensors

--- a/src/alarm.c
+++ b/src/alarm.c
@@ -1,0 +1,18 @@
+#include "alarm.h"
+
+uint16_t get_battery_value(void) {
+    /* Configure the ADC */
+    adc_set_regular_sequence(ADC1, 1, ADC_CHANNEL_BATTERY_LEVEL); /* Select only one channel */
+
+    /* Start the conversion */
+    adc_start_conversion_regular(ADC1);
+
+    /* Wait for the conversion to complete */
+    while (!(ADC1_SR & ADC_SR_EOC));
+
+    /* Read the conversion result */
+    return adc_read_regular(ADC1) * CONVERT_VALUE;
+}
+
+
+


### PR DESCRIPTION
## Dependencies
This change depends on the PlatformIO environment configuration to ensure that hardware dependencies and platform-specific settings are available for the proper execution of ADC reads and battery level processing.

## What?
A function `get_battery_value()` was added to read the ADC value and convert it to a battery level percentage, interpreting a voltage range from 0 to 5V as a percentage between 0 and 100%. The function returns the battery level as an integer from 0 to 100, representing the battery charge state based on the input voltage.

## Why?
This change enables flexible battery monitoring by providing a percentage-based reading. It is useful for applications that need to know the battery charge level in real-time, allowing decisions to be made based on battery level without needing to interpret the raw ADC value.

## How?
- The ADC is configured with a 12-bit resolution (maximum value of 4095) and a 5V reference voltage.
- The function reads the ADC value and normalizes it to a value between 0 and 100%.