### PR TITLE
[FEATURE][#2] Show temperature in display

### DIFF
--- a/include/alarm.h
+++ b/include/alarm.h
@@ -36,5 +36,13 @@ void display_temperature(uint8_t value, uint8_t address, uint32_t i2c);
 
 /**
  * @brief Update the I2C value
+ * @param i2c The I2C peripheral
+ * @param data The data to update
+ * @param address The address of the device
  */
-void update_i2c_value(void);
+void update_i2c_value(uint32_t i2c, uint8_t data, uint8_t address);
+
+/**
+ * @brief Show the display
+ */
+void show_display(void);

--- a/include/alarm.h
+++ b/include/alarm.h
@@ -46,3 +46,4 @@ void update_i2c_value(uint32_t i2c, uint8_t data, uint8_t address);
  * @brief Show the display
  */
 void show_display(void);
+

--- a/include/alarm.h
+++ b/include/alarm.h
@@ -1,0 +1,40 @@
+#include <libopencm3/stm32/i2c.h> /**< For I2C peripheral */
+#include "system_response.h" /**< For read_temperature() */
+
+#define WRITE 0 /**< Write mode */
+#define READ 1  /**< Read mode */
+
+#define DISPLAY_UNIT_ADDRESS 0x3F /**< Display unit address */
+#define DISPLAY_TENS_ADDRESS 0x3E /**< Display tens address */
+
+/**
+ * @brief Convert a value to the display format
+ * @param value The value to convert
+ * @return The value in the display format
+ */
+uint8_t convert_to_display(uint8_t value);
+
+/**
+ * @brief Obtain the temperature value
+ * @return The unit value in the display format
+ */
+uint8_t obtain_unit_value(void);
+
+/**
+ * @brief Obtain the temperature value
+ * @return The tens value in the display format
+ */
+uint8_t obtain_tens_value(void);
+
+/**
+ * @brief Display the temperature value
+ * @param value The value to display
+ * @param address The address of the device
+ * @param i2c The I2C peripheral
+ */
+void display_temperature(uint8_t value, uint8_t address, uint32_t i2c);
+
+/**
+ * @brief Update the I2C value
+ */
+void update_i2c_value(void);

--- a/src/alarm.c
+++ b/src/alarm.c
@@ -19,7 +19,7 @@ uint8_t convert_to_display(uint8_t value) {
 uint8_t obtain_unit_value(void) {
     uint16_t temperature = read_temperature(); /* Read the temperature */
 
-    if (temperature > 100) {
+    if (temperature > 99) {
         return 0x31 /* Display "r" for error */;
     }
 
@@ -30,7 +30,7 @@ uint8_t obtain_unit_value(void) {
 uint8_t obtain_tens_value(void) {
     uint16_t temperature = read_temperature();
 
-    if (temperature > 100) { /* Check if the temperature is greater than 100 */
+    if (temperature > 99) { /* Check if the temperature is greater than 99 */
         return 0x79; /* Display "E" for error */
     }
 
@@ -69,3 +69,4 @@ void show_display(void){
     update_i2c_value(I2C1_BASE, unit, DISPLAY_UNIT_ADDRESS); /* Update the I2C value */
     update_i2c_value(I2C2_BASE, tens, DISPLAY_TENS_ADDRESS); /* Update the I2C value */
 }
+

--- a/src/alarm.c
+++ b/src/alarm.c
@@ -1,0 +1,72 @@
+#include "alarm.h"
+
+uint8_t convert_to_display(uint8_t value) {
+    switch (value) {
+        case 0: return 0x3F; /* Display "0" */
+        case 1: return 0x06; /* Display "1" */
+        case 2: return 0x5B; /* Display "2" */
+        case 3: return 0x4F; /* Display "3" */
+        case 4: return 0x66; /* Display "4" */
+        case 5: return 0x6D; /* Display "5" */
+        case 6: return 0x7D; /* Display "6" */
+        case 7: return 0x07; /* Display "7" */
+        case 8: return 0x7F; /* Display "8" */
+        case 9: return 0x6F; /* Display "9" */
+        default: return 0x3F; /* Display "0" */
+    }
+}
+
+uint8_t obtain_unit_value(void) {
+    uint16_t temperature = read_temperature(); /* Read the temperature */
+
+    if (temperature > 100) {
+        return 0x31 /* Display "r" for error */;
+    }
+
+    uint8_t unit = temperature % 10; /* Obtain the unit value */
+    return convert_to_display(unit); /* Convert the value to the display format */
+}
+
+uint8_t obtain_tens_value(void) {
+    uint16_t temperature = read_temperature();
+
+    if (temperature > 100) { /* Check if the temperature is greater than 100 */
+        return 0x79; /* Display "E" for error */
+    }
+
+    uint8_t tens = temperature / 10; /* Obtain the tens value */
+    return convert_to_display(tens); /* Convert the value to the display format */
+}
+
+void display_temperature(uint8_t value, uint8_t address, uint32_t i2c) {
+
+    i2c_peripheral_enable(i2c); /* Enable the I2C peripheral */
+    
+    i2c_send_start(i2c); /* Send the start condition */
+    i2c_send_7bit_address(i2c, address, WRITE); /* Send the address of the device */
+    while (!(i2c_get_data(i2c) & (1 << 1)));        /* Wait for the address to be sent */
+
+    i2c_send_data(i2c, value);                       /* Send the data */
+
+}
+
+void update_i2c_value(void) {
+
+    uint8_t tens = obtain_tens_value(); /* Obtain the tens value */
+    uint8_t unit = obtain_unit_value(); /* Obtain the unit value */
+
+    while (!(i2c_get_data(I2C1_BASE) & (1 << 1)));        /* Wait for the data to be sent */
+    i2c_send_stop(I2C1_BASE);                             /* Send the stop condition */
+
+    i2c_peripheral_disable(I2C1_BASE);        /* Disable the I2C peripheral */
+
+    display_temperature(tens, DISPLAY_UNIT_ADDRESS, I2C1_BASE);
+
+    while (!(i2c_get_data(I2C2_BASE) & (1 << 1)));        /* Wait for the data to be sent */
+    i2c_send_stop(I2C2_BASE);                             /* Send the stop condition */
+
+    i2c_peripheral_disable(I2C2_BASE);        /* Disable the I2C peripheral */
+
+    display_temperature(unit, DISPLAY_TENS_ADDRESS, I2C2_BASE); /* Send the data */
+
+}

--- a/src/alarm.c
+++ b/src/alarm.c
@@ -50,23 +50,22 @@ void display_temperature(uint8_t value, uint8_t address, uint32_t i2c) {
 
 }
 
-void update_i2c_value(void) {
+void update_i2c_value(uint32_t i2c, uint8_t data, uint8_t address) {
 
-    uint8_t tens = obtain_tens_value(); /* Obtain the tens value */
+    while (!(i2c_get_data(ic2) & (1 << 1)));        /* Wait for the data to be sent */
+    i2c_send_stop(ic2);                             /* Send the stop condition */
+
+    i2c_peripheral_disable(ic2);        /* Disable the I2C peripheral */
+
+    display_temperature(data, address, i2c); /* Display the temperature value */
+
+}
+
+void show_display(void){
+    
     uint8_t unit = obtain_unit_value(); /* Obtain the unit value */
+    uint8_t tens = obtain_tens_value(); /* Obtain the tens value */
 
-    while (!(i2c_get_data(I2C1_BASE) & (1 << 1)));        /* Wait for the data to be sent */
-    i2c_send_stop(I2C1_BASE);                             /* Send the stop condition */
-
-    i2c_peripheral_disable(I2C1_BASE);        /* Disable the I2C peripheral */
-
-    display_temperature(tens, DISPLAY_UNIT_ADDRESS, I2C1_BASE);
-
-    while (!(i2c_get_data(I2C2_BASE) & (1 << 1)));        /* Wait for the data to be sent */
-    i2c_send_stop(I2C2_BASE);                             /* Send the stop condition */
-
-    i2c_peripheral_disable(I2C2_BASE);        /* Disable the I2C peripheral */
-
-    display_temperature(unit, DISPLAY_TENS_ADDRESS, I2C2_BASE); /* Send the data */
-
+    update_i2c_value(I2C1_BASE, unit, DISPLAY_UNIT_ADDRESS); /* Update the I2C value */
+    update_i2c_value(I2C2_BASE, tens, DISPLAY_TENS_ADDRESS); /* Update the I2C value */
 }

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -90,6 +90,26 @@ void config_i2c(void)
 
     // Enable I2C to start communication
     i2c_peripheral_enable(I2C1);
+
+    // Enable clock for and I2C2
+    rcc_periph_clock_enable(RCC_I2C2);
+
+    // GPIO pins configuration for SDA and SCL 
+    gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_50_MHZ,
+              GPIO_CNF_OUTPUT_ALTFN_OPENDRAIN,
+              GPIO_I2C2_SCL | GPIO_I2C2_SDA);
+
+    // Disable I2C1 before configurating it
+    i2c_peripheral_disable(I2C2);
+
+    // I2C basic configuration
+    i2c_set_clock_frequency(I2C2, I2C_CR2_FREQ_36MHZ);
+    i2c_set_standard_mode(I2C2);
+    i2c_set_trise(I2C2, I2C1_TRISE_100KHZ); // Rising time in standard mode
+    i2c_set_ccr(I2C2, I2C1_CCR_100KHZ);  // Set the CCR to 100 kHz
+
+    // Enable I2C to start communication
+    i2c_peripheral_enable(I2C2);
 }
 
 void config_pwm(void) 


### PR DESCRIPTION
## Dependencies
This change depends on configuring GPIO pins for controlling the 7-segment displays and setting up interrupts to periodically update the display.

## What?
The code configures two GPIO ports for controlling the two 7-segment displays. It reads the temperature from a sensor, processes the temperature into tens and units digits, and displays them on the 7-segment displays. An interrupt periodically triggers updates to the display to reflect the current temperature.

## Why?
GPIO pins are configured for output to control the 7-segment displays, which show the temperature values. The interrupt is used to periodically refresh the displays without blocking the main program flow, allowing for smooth and consistent updates.

## How?
1. **GPIO Configuration**: Two GPIO ports are set up for output to drive the 7-segment displays.
2. **Temperature Read**: The temperature is read from a sensor (you can use a simple function to simulate this).
3. **Interrupt Configuration**: An interrupt is configured to periodically trigger a function to update the display.
